### PR TITLE
add subloader concept

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,12 +118,43 @@ To tell the Opal compiler to stub out certain dependencies, do this
     loaders: [
       {
         test: /\.rb?$/,
-        loader: 'opalrb-loader'
+        loader: 'opal-webpack'
       }
     ]
   },
   opal: {
     stubs: ['dependency']
+  }
+}
+```
+
+### Subloaders
+
+Because of the way that opal-webpack has to be structured internally, you are not
+able to chain loaders in the normal way if you want to moidfy the ruby files
+before they are sent to Opal. As an alternative, we have the concept of subloaders.
+These act exactly the same as the normal `loaders` object, just defined directly
+on the options for opal-webpack.
+
+```js
+{
+  module: {
+    entry: 'opal-webpack!./main.rb'
+  },
+  opal: {
+    loaders: [{
+      test: /foo.rb?$/,
+      loader: 'foo-loader'
+    }, {
+      test: /bar.rb?$/,
+      loader: ['bar-loader', 'baz']
+    }, {
+      test: /qux.rb?$/,
+      loader: 'fake-loader',
+      query: {
+        other: 'thing'
+      }
+    }]
   }
 }
 ```

--- a/lib/getWebpackRequire.js
+++ b/lib/getWebpackRequire.js
@@ -9,13 +9,40 @@ function filterNonQueryPassOptions(options) {
   delete passOnOptions.sourceMap
   // stubs are global, do not want to locally override these
   delete passOnOptions.stubs
+  delete passOnOptions.loaders
   delete passOnOptions.externalOpal
   return passOnOptions
+}
+
+function getSubLoaders(subLoaders, absolutePath) {
+  let result = '!'
+
+  if (Array.isArray(subLoaders)) {
+    subLoaders
+      .filter(sL => absolutePath.match(sL.test))
+      .forEach(sL => {
+        if (Array.isArray(sL.loader)) {
+          result += sL.loader.join('!') + '!'
+        } else if (typeof sL.loader === 'string') {
+          result += sL.loader
+          if ('query' in sL) {
+            var query = JSON.stringify(sL.query)
+            // since we are using a single quote in the resulting require call,
+            // we need to escape it here to prevent it from breaking the require
+            query = query.replace(/'/g, "\\'")
+            result += `?${query}`
+          }
+        }
+      })
+  }
+
+  return result
 }
 
 const noRequireable = require('./getOpalRequiresForStubbing')
 
 module.exports = function(context, options, relativePath, absolutePath) {
+  const subLoaders = getSubLoaders(options.loaders, absolutePath)
   const passOnOptions = filterNonQueryPassOptions(options)
   const requirable = noRequireable.indexOf(relativePath) == -1
   Object.assign(passOnOptions, {
@@ -23,5 +50,5 @@ module.exports = function(context, options, relativePath, absolutePath) {
     requirable: requirable
   })
   const flat = queryString.stringify(passOnOptions)
-  return `require('!!${context.path}?${flat}!${absolutePath}');`
+  return `require('!!${context.path}?${flat}${subLoaders}!${absolutePath}');`
 }


### PR DESCRIPTION
some of the gems that my projects depend on are not natively able to be
compiled by Opal (they use stuff like mutable strings, etc). Rather than fork
an entire gem to effectively change a `>>` to a `+=`, I'd love to be able to
use something like
[string-replace-loader](https://www.npmjs.com/package/string-replace-loader).
But, because of the (very clever) way that y'all use the `!!` in
getWebpackRequire, all of the loaders I try to add only effect the initial
entry point. Ideally this would actually just grab the original global config
loaders object, and just insert any matched routes from there. But I have not
been able to figure out a way to get the global webpack config from inside of
the loader.

Therefore, I thought having the ability to define additional loaders as an
option to opal-webpack would be a good, extensible way to accomplish this.

Hope you find it useful, and thanks so much for the project either way.